### PR TITLE
redid .css to avoid conflicts with class prefixes

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -25,7 +25,8 @@ class App extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className='nssh-main'>
+        <h1 className='nssh-h1'>Nearby Similar Homes</h1>
         <HomesList homes={this.state.homes} />
       </div>
     );

--- a/client/components/Home.jsx
+++ b/client/components/Home.jsx
@@ -1,33 +1,33 @@
 import React from 'react';
 
 const Home = (props) => (
-  <div className='home'>
-    <div className='container'>
-      <img src={props.home.imageUrl}></img>
-      <div className='notes'>
-        <div className='new' style={{ display: props.home.age <= 48 ? '' : 'none' }}>NEW {props.home.age} {props.home.age === 1 ? 'HOUR AGO' : 'HOURS AGO'}</div>
+  <div className='nssh-home'>
+    <div className='nssh-container'>
+      <img className='nssh-img' src={props.home.imageUrl}></img>
+      <div className='nssh-notes'>
+        <div className='nssh-new' style={{ display: props.home.age <= 48 ? '' : 'none' }}>NEW {props.home.age} {props.home.age === 1 ? 'HOUR AGO' : 'HOURS AGO'}</div>
         <div style={{ display: props.home.videoTour ? '' : 'none' }}>VIDEO TOUR</div>
         <div style={{ display: props.home['3dWalkthrough'] ? '' : 'none' }}>3D WALKTHROUGH</div>
       </div>
-      <div className='arrow left-arrow' onClick={() => { props.goLeft(); }} style={{ display: props.idx === 0 ? 'none' : '' }}>{'<'}</div>
-      <div className='arrow right-arrow' onClick={() => { props.goRight(); }} style={{ display: props.idx === props.max ? 'none' : '' }}>{'>'}</div>
+      <div className='nssh-arrow nssh-left-arrow' onClick={() => { props.goLeft(); }} style={{ display: props.idx === 0 ? 'none' : '' }}>{'<'}</div>
+      <div className='nssh-arrow nssh-right-arrow' onClick={() => { props.goRight(); }} style={{ display: props.idx === props.max ? 'none' : '' }}>{'>'}</div>
     </div>
-    <div className='text'>
-      <div className='price'>${props.home.price + ',000'}</div>
-      <div className='all-ammenities'>
-        <div className='ammenities'>{props.home.beds} {props.home.beds === 1 ? 'bed' : 'beds'}</div>
-        <div className='ammenities'>{props.home.baths} {props.home.baths === 1 ? 'bath' : 'baths'}</div>
-        <div className='ammenities'>{props.home.size.toString().length > 3 ? props.home.size.toString()[0] + ',' + props.home.size.toString().slice(1) : props.home.size.toString()} Sq. Ft.</div>
+    <div className='nssh-text'>
+      <div className='nssh-price'>${props.home.price + ',000'}</div>
+      <div className='nssh-all-ammenities'>
+        <div className='nssh-ammenities'>{props.home.beds} {props.home.beds === 1 ? 'bed' : 'beds'}</div>
+        <div className='nssh-ammenities'>{props.home.baths} {props.home.baths === 1 ? 'bath' : 'baths'}</div>
+        <div className='nssh-ammenities'>{props.home.size.toString().length > 3 ? props.home.size.toString()[0] + ',' + props.home.size.toString().slice(1) : props.home.size.toString()} Sq. Ft.</div>
       </div>
-      <div className='address'>{`${props.home.address.number} ${props.home.address.streetName} ${props.home.address.streetSuffix}, ${props.home.address.city}, ${props.home.address.state} ${props.home.address.zipcode}`}</div>
-      <div className='realty'>
+      <div className='nssh-address'>{`${props.home.address.number} ${props.home.address.streetName} ${props.home.address.streetSuffix}, ${props.home.address.city}, ${props.home.address.state} ${props.home.address.zipcode}`}</div>
+      <div className='nssh-realty'>
         <div>{props.home.realtor}</div>
         <div>·</div>
         <div>{props.home.agency}</div>
         <div>•</div>
         <div>MLS {props.home.listing}</div>
       </div>
-      <div className='tags'>
+      <div className='nssh-tags'>
         {props.home.tags.split(',').map((tag, i) => (<div key={i}>{tag}</div>))}
       </div>
     </div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,6 @@
   <link rel='stylesheet' href='./main.css'>
 </head>
 <body>
-  <h1>Nearby Similar Homes</h1>
   <div id='similar-homes-app'></div>
   <script src='./main.js'></script>
 </body>

--- a/dist/main.css
+++ b/dist/main.css
@@ -1,31 +1,31 @@
-body {
+.nssh-main {
   font-family: 'Open Sans', sans-serif;
   font-weight: lighter;
 }
-h1 {
+.nssh-h1 {
   font-size: 125%;
 }
-.text {
+.nssh-text {
   padding-left: 15px;
 }
-.ammenities {
+.nssh-ammenities {
   display: inline;
   padding-right: 10px;
 }
-.realty div {
+.nssh-realty div {
   display: inline;
   padding-right: 3px;
   color: rgb(170, 170, 170);
   font-size: 70%;
 }
-.realty {
+.nssh-realty {
   padding-bottom: 10px;
 }
-.tags {
+.nssh-tags {
   padding-bottom: 35px;
   display: flex;
 }
-.tags div {
+.nssh-tags div {
   display: inline;
   margin-right: 5px;
   padding-left: 10px;
@@ -36,40 +36,40 @@ h1 {
   border-radius: 20px;
   font-size: 85%;
 }
-.price {
+.nssh-price {
   font-weight: bold;
   font-size: 125%;
   padding-top: 10px;
   padding-bottom: 7px;
 }
-.address {
+.nssh-address {
   padding-top: 5px;
   padding-bottom: 5px;
   font-size: 85%
 }
-img {
+.nssh-img {
   height: 260px;
   width: 390px;
 }
-.home {
+.nssh-home {
   box-shadow: 0 0 10px rgb(226, 226, 226);
   margin-right: 647px;
   width: 390px;
 }
-.home:hover {
+.nssh-home:hover {
   box-shadow: 0 0 10px rgb(139, 134, 134);
 }
-.container {
+.nssh-container {
   position: relative;
   text-align: center;
   width: 390px;
 }
-.container .notes {
+.nssh-container .nssh-notes {
   position: absolute;
   top: 8px;
   left: 5px;
 }
-.container .notes div {
+.nssh-container .nssh-notes div {
   background-color: #7556f2;
   color: white;
   border-radius: 20px;
@@ -81,24 +81,24 @@ img {
   font-size: 75%;
   display: inline;
 }
-.container .notes .new {
+.nssh-container .nssh-notes .nssh-new {
   background-color: green;
 }
 
-.container .arrow {
+.nssh-container .nssh-arrow {
   top: 200px;
   border: 1px solid black;
   border-radius: 100px;
   background-color: white;
 }
 
-.container .left-arrow {
+.nssh-container .nssh-left-arrow {
   position: absolute;
   left: -10px;
   font-size: 150%;
 }
 
-.container .right-arrow {
+.nssh-container .nssh-right-arrow {
   position: absolute;
   left: 385px;
   font-size: 150%;


### PR DESCRIPTION
This is a quick fix at what would ideally be done with .css modules or React styled components. Should be able to load my .css file without modifying any DOM elements other than my own.